### PR TITLE
Fix Order-OrderItem Relationship and Inventory Movement Creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ A basic inventory management REST API built with **Spring Boot**, designed to ha
 - **Inventory Movements**: Manually register `IN` (incoming) or `OUT` (outgoing) stock operations.
 - **Stock Updates**: Stock levels are automatically updated when a movement is created.
 - **Date-based Queries**: Retrieve orders or movements between date ranges.
+- **User Authentication**: Register users with different roles `EMPLOYEE` or `ADMIN`.
+- **User Uthorization**: Protect endpoints based on user role.
 
 ## 🧠 Tech Stack
 
@@ -19,6 +21,7 @@ A basic inventory management REST API built with **Spring Boot**, designed to ha
 - Spring Boot 3
 - Spring Data JPA
 - MySQL (or any SQL database)
+- Spring Security - JWT
 - MapStruct
 - Maven
 - Lombok
@@ -79,8 +82,6 @@ Set variables in .vscode/launch.json or your environment before running the app.
 ```
 
 ## 📌 Next Steps
-
-- Secure the API with Spring Security (role-based access)
 
 - Automate inventory movements from order processing
 

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,27 @@
 			<artifactId>mapstruct</artifactId>
 			<version>1.5.5.Final</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-api</artifactId>
+			<version>0.11.5</version>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-impl</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.jsonwebtoken</groupId>
+			<artifactId>jjwt-jackson</artifactId>
+			<version>0.11.5</version>
+			<scope>runtime</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/com/sebastian/inventory_management/DTO/Auth/AuthenticationRequest.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Auth/AuthenticationRequest.java
@@ -1,26 +1,19 @@
-package com.sebastian.inventory_management.DTO.User;
-
-import com.sebastian.inventory_management.enums.Role;
+package com.sebastian.inventory_management.DTO.Auth;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
-public class UserRequestDTO {
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuthenticationRequest {
     
-    @NotBlank(message = "Username is required")
-    @Size(min = 3, max = 30, message = "Username must be between 3 and 30 characters")
-    private String username;
-
     @NotBlank(message = "Email is required")
     @Email(message = "Invalid email format")
     private String email;
@@ -28,7 +21,5 @@ public class UserRequestDTO {
     @NotBlank(message = "Password is required")
     @Size(min = 6, message = "Password must be at least 6 characters")
     private String password;
-
-    @NotNull(message = "Role is required")
-    private Role role;
+    
 }

--- a/src/main/java/com/sebastian/inventory_management/DTO/Auth/AuthenticationResponse.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Auth/AuthenticationResponse.java
@@ -1,0 +1,18 @@
+package com.sebastian.inventory_management.DTO.Auth;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AuthenticationResponse {
+
+    private String token;
+    private String username;
+    private String role;
+
+}

--- a/src/main/java/com/sebastian/inventory_management/DTO/Auth/RegisterRequest.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Auth/RegisterRequest.java
@@ -1,4 +1,4 @@
-package com.sebastian.inventory_management.DTO.User;
+package com.sebastian.inventory_management.DTO.Auth;
 
 import com.sebastian.inventory_management.enums.Role;
 
@@ -11,12 +11,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @Setter
-public class UserRequestDTO {
-    
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegisterRequest {
+
     @NotBlank(message = "Username is required")
     @Size(min = 3, max = 30, message = "Username must be between 3 and 30 characters")
     private String username;
@@ -31,4 +31,5 @@ public class UserRequestDTO {
 
     @NotNull(message = "Role is required")
     private Role role;
+
 }

--- a/src/main/java/com/sebastian/inventory_management/DTO/Category/CategoryRequestDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Category/CategoryRequestDTO.java
@@ -1,6 +1,7 @@
 package com.sebastian.inventory_management.DTO.Category;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import lombok.Setter;
 public class CategoryRequestDTO {
 
     @NotBlank(message = "Name is mandatory")
+    @Size(max = 100, message = "Name must be less than 100 characters")
     private String name;
-    
+
 }

--- a/src/main/java/com/sebastian/inventory_management/DTO/InventoryMovement/InventoryMovementRequestDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/InventoryMovement/InventoryMovementRequestDTO.java
@@ -2,6 +2,7 @@ package com.sebastian.inventory_management.DTO.InventoryMovement;
 
 import com.sebastian.inventory_management.enums.MovementType;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -13,8 +14,9 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class InventoryMovementRequestDTO {
-    
+
     @NotNull(message = "Quantity is required")
+    @Min(value = 1, message = "Quantity must be at least 1")
     private Integer quantity;
 
     @NotNull(message = "Product ID is required")

--- a/src/main/java/com/sebastian/inventory_management/DTO/InventoryMovement/InventoryMovementResponseDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/InventoryMovement/InventoryMovementResponseDTO.java
@@ -2,6 +2,7 @@ package com.sebastian.inventory_management.DTO.InventoryMovement;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sebastian.inventory_management.enums.MovementType;
 
 import lombok.AllArgsConstructor;
@@ -17,7 +18,10 @@ public class InventoryMovementResponseDTO {
     
     private Long id;
     private Integer quantity;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime timestamp;
+    
     private Long productId;
     private String productName;
     private Long userId;

--- a/src/main/java/com/sebastian/inventory_management/DTO/Order/OrderRequestDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Order/OrderRequestDTO.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.sebastian.inventory_management.DTO.OrderItem.OrderItemRequestDTO;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -21,6 +22,7 @@ public class OrderRequestDTO {
     private Long supplierId;
 
     @NotEmpty(message = "Order must contain at least one item")
-    private List<OrderItemRequestDTO> items;
+    @Valid
+    private List<@Valid OrderItemRequestDTO> items;
 
 }

--- a/src/main/java/com/sebastian/inventory_management/DTO/Order/OrderResponseDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Order/OrderResponseDTO.java
@@ -3,6 +3,7 @@ package com.sebastian.inventory_management.DTO.Order;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sebastian.inventory_management.DTO.OrderItem.OrderItemResponseDTO;
 
 import lombok.AllArgsConstructor;
@@ -18,6 +19,8 @@ public class OrderResponseDTO {
     
     private Long id;
     private String orderNumber;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime orderDate;
 
     private Long supplierId;

--- a/src/main/java/com/sebastian/inventory_management/DTO/OrderItem/OrderItemRequestDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/OrderItem/OrderItemRequestDTO.java
@@ -2,6 +2,8 @@ package com.sebastian.inventory_management.DTO.OrderItem;
 
 import java.math.BigDecimal;
 
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -14,14 +16,16 @@ import lombok.Setter;
 @AllArgsConstructor
 @NoArgsConstructor
 public class OrderItemRequestDTO {
-    
-    @NotNull(message = "Quantity cannot be null")
-    @Min(1)
-    private int quantity;
 
-    @NotNull(message = "Price cannot be null")
+    @NotNull(message = "Quantity is required")
+    @Min(value = 1, message = "Quantity must be at least 1")
+    private Integer quantity;
+
+    @NotNull(message = "Price is required")
+    @DecimalMin(value = "0.01", inclusive = true, message = "Price must be greater than 0")
+    @Digits(integer = 10, fraction = 2, message = "Price must be a valid monetary amount (max 2 decimal places)")
     private BigDecimal price;
 
-    @NotNull(message = "Product cannot be null")
+    @NotNull(message = "Product ID is required")
     private Long productId;
 }

--- a/src/main/java/com/sebastian/inventory_management/DTO/Product/ProductRequestDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Product/ProductRequestDTO.java
@@ -20,25 +20,25 @@ import lombok.Setter;
 public class ProductRequestDTO {
 
     @NotBlank(message = "Name is mandatory")
-    @Size(max = 100, message = "Name must be less than 100 characters")
+    @Size(max = 100, message = "Name must be at most 100 characters")
     private String name;
-
+    
     @NotBlank(message = "Description is mandatory")
-    @Size(max = 255, message = "Description must be less than 255 characters")
+    @Size(max = 255, message = "Description must be at most 255 characters")
     private String description;
-
-    @NotNull(message = "Stock cannot be null")
+    
+    @NotNull(message = "Stock is required")
     @Min(value = 0, message = "Stock cannot be negative")
-    private int stock;
-
-    @NotNull(message = "Price cannot be null")
-    @DecimalMin(value = "0.0", inclusive = false, message = "Price must be greater than zero")
-    @Digits(integer = 10, fraction = 2, message = "Price format is invalid")
+    private Integer stock;
+    
+    @NotNull(message = "Price is required")
+    @DecimalMin(value = "0.01", inclusive = true, message = "Price must be greater than 0")
+    @Digits(integer = 10, fraction = 2, message = "Price must be a valid monetary amount (max 2 decimal places)")
     private BigDecimal price;
-
-    @NotNull(message = "Category cannot be null")
+    
+    @NotNull(message = "Category ID is required")
     private Long categoryId;
-
-    @NotNull(message = "Supplier cannot be null")
+    
+    @NotNull(message = "Supplier ID is required")
     private Long supplierId;
 }

--- a/src/main/java/com/sebastian/inventory_management/DTO/Supplier/SupplierRequestDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Supplier/SupplierRequestDTO.java
@@ -3,6 +3,7 @@ package com.sebastian.inventory_management.DTO.Supplier;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -15,13 +16,15 @@ import lombok.Setter;
 public class SupplierRequestDTO {
     
     @NotBlank(message = "Name is mandatory")
+    @Size(max = 100, message = "Name must be at most 100 characters")
     private String name;
 
     @NotBlank(message = "Contact email is mandatory")
-    @Email(message = "Invalid email format") 
+    @Email(message = "Invalid email format")
+    @Size(max = 100, message = "Email must be at most 100 characters")
     private String contactEmail;
 
     @NotBlank(message = "Phone number is mandatory")
-    @Pattern(regexp = "\\d{10,15}", message = "Invalid phone number")
+    @Pattern(regexp = "\\d{10,15}", message = "Phone number must contain 10 to 15 digits")
     private String phoneNumber;
 }

--- a/src/main/java/com/sebastian/inventory_management/config/ApplicationConfig.java
+++ b/src/main/java/com/sebastian/inventory_management/config/ApplicationConfig.java
@@ -1,0 +1,37 @@
+package com.sebastian.inventory_management.config;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.sebastian.inventory_management.repository.UserRepository;
+
+@Configuration
+public class ApplicationConfig {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public ApplicationConfig(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public AuthenticationProvider authenticationProvider() {
+        DaoAuthenticationProvider authProvider = new DaoAuthenticationProvider();
+        authProvider.setUserDetailsService(email -> userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found")));
+        authProvider.setPasswordEncoder(passwordEncoder());
+        return authProvider;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/config/JacksonConfig.java
+++ b/src/main/java/com/sebastian/inventory_management/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.sebastian.inventory_management.config;
+
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/controller/AuthController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/AuthController.java
@@ -1,0 +1,40 @@
+package com.sebastian.inventory_management.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sebastian.inventory_management.DTO.Auth.AuthenticationRequest;
+import com.sebastian.inventory_management.DTO.Auth.AuthenticationResponse;
+import com.sebastian.inventory_management.DTO.Auth.RegisterRequest;
+import com.sebastian.inventory_management.security.AuthService;
+
+import jakarta.validation.Valid;
+
+@RestController
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final AuthService authenticationService;
+
+    @Autowired
+    public AuthController(AuthService authenticationService) {
+        this.authenticationService = authenticationService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<AuthenticationResponse> login(@Valid @RequestBody AuthenticationRequest request) {
+        AuthenticationResponse response = authenticationService.login(request);
+        return ResponseEntity.status(HttpStatus.OK).body(response);
+    }
+
+    @PostMapping("/register")
+    public ResponseEntity<AuthenticationResponse> register(@Valid @RequestBody RegisterRequest request) {
+        AuthenticationResponse response = authenticationService.register(request);
+        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/controller/CategoryController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/CategoryController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -30,37 +31,43 @@ public class CategoryController {
     public CategoryController(ICategoryService categoryService) {
         this.categoryService = categoryService;
     }
-    
+
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<CategoryResponseDTO> createCategory(@Valid @RequestBody CategoryRequestDTO categoryRequest) {
         CategoryResponseDTO createdCategory = categoryService.saveCategory(categoryRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdCategory);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/{id}")
     public ResponseEntity<CategoryResponseDTO> getCategoryById(@PathVariable Long id) {
         CategoryResponseDTO category = categoryService.getCategoryById(id);
         return ResponseEntity.status(HttpStatus.OK).body(category);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/name/{name}")
     public ResponseEntity<CategoryResponseDTO> getCategoryByName(@PathVariable String name) {
         CategoryResponseDTO category = categoryService.getCategoryByName(name);
         return ResponseEntity.status(HttpStatus.OK).body(category);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping
     public ResponseEntity<List<CategoryResponseDTO>> getAllCategories(){
         List<CategoryResponseDTO> categories = categoryService.getAllCategories();
         return ResponseEntity.status(HttpStatus.OK).body(categories);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteCategeory(@PathVariable Long id){
         categoryService.deleteCategory(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<CategoryResponseDTO> updateCategory(@PathVariable Long id, @Valid @RequestBody CategoryRequestDTO categoryRequest) {
         CategoryResponseDTO updatedCategory = categoryService.updateCategory(id, categoryRequest);

--- a/src/main/java/com/sebastian/inventory_management/controller/InventoryMovementController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/InventoryMovementController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,36 +33,42 @@ public class InventoryMovementController {
         this.inventoryMovementService = inventoryMovementService;
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<InventoryMovementResponseDTO> addMovement(@Valid @RequestBody InventoryMovementRequestDTO request) {
         InventoryMovementResponseDTO createdMovement = inventoryMovementService.addMovement(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdMovement);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/{id}")
     public ResponseEntity<InventoryMovementResponseDTO> getMovementById(@PathVariable Long id) {
         InventoryMovementResponseDTO movement = inventoryMovementService.getMovementById(id);
         return ResponseEntity.ok(movement);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping
     public ResponseEntity<List<InventoryMovementResponseDTO>> getAllMovements() {
         List<InventoryMovementResponseDTO> movements = inventoryMovementService.getAllMovements();
         return ResponseEntity.ok(movements);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/product/{productId}")
     public ResponseEntity<List<InventoryMovementResponseDTO>> getMovementsByProduct(@PathVariable Long productId) {
         List<InventoryMovementResponseDTO> movements = inventoryMovementService.findByProductId(productId);
         return ResponseEntity.ok(movements);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/user/{userId}")
     public ResponseEntity<List<InventoryMovementResponseDTO>> getMovementsByUser(@PathVariable Long userId) {
         List<InventoryMovementResponseDTO> movements = inventoryMovementService.findByUserId(userId);
         return ResponseEntity.ok(movements);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/between-dates")
     public ResponseEntity<List<InventoryMovementResponseDTO>> getMovementsBetweenDates(
             @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,

--- a/src/main/java/com/sebastian/inventory_management/controller/OrderController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/OrderController.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -34,36 +35,42 @@ public class OrderController {
         this.orderService = orderService;
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<OrderResponseDTO> createOrder(@RequestBody @Valid OrderRequestDTO orderDTO) {
         OrderResponseDTO createdOrder = orderService.createOrder(orderDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdOrder);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/{id}")
     public ResponseEntity<OrderResponseDTO> getOrderById(@PathVariable Long id) {
         OrderResponseDTO order = orderService.getOrderById(id);
         return ResponseEntity.status(HttpStatus.OK).body(order);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/number/{orderNumber}")
     public ResponseEntity<OrderResponseDTO> getOrderByNumber(@PathVariable String orderNumber) {
         OrderResponseDTO order = orderService.getOrderByOrderNumber(orderNumber);
         return ResponseEntity.status(HttpStatus.OK).body(order);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping
     public ResponseEntity<List<OrderResponseDTO>> getAllOrders() {
         List<OrderResponseDTO> orders = orderService.getAllOrders();
         return ResponseEntity.status(HttpStatus.OK).body(orders);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/supplier/{supplierId}")
     public ResponseEntity<List<OrderResponseDTO>> getOrdersBySupplier(@PathVariable Long supplierId) {
         List<OrderResponseDTO> orders = orderService.getOrdersBySupplier(supplierId);
         return ResponseEntity.status(HttpStatus.OK).body(orders);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/between-dates")
     public ResponseEntity<List<OrderResponseDTO>> getOrdersBetweenDates(
             @RequestParam("start") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime start,
@@ -71,12 +78,14 @@ public class OrderController {
         return ResponseEntity.ok(orderService.getOrdersBetweenDates(start, end));
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<OrderResponseDTO> updateOrder(@PathVariable Long id, @RequestBody @Valid OrderRequestDTO orderDTO) {
         OrderResponseDTO updatedOrder = orderService.updateOrder(id, orderDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updatedOrder);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteOrder(@PathVariable Long id) {
         orderService.deleteOrder(id);

--- a/src/main/java/com/sebastian/inventory_management/controller/ProductController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/ProductController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,66 +30,77 @@ public class ProductController {
         this.productService = productService;
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<ProductResponseDTO> createProduct(@Valid @RequestBody ProductRequestDTO productRequest) {
         ProductResponseDTO createdProduct = productService.saveProduct(productRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdProduct);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping
     public ResponseEntity<List<ProductResponseDTO>> getAllProducts() {
         List<ProductResponseDTO> products = productService.getAllProducts();
         return ResponseEntity.status(HttpStatus.OK).body(products);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/{id}")
     public ResponseEntity<ProductResponseDTO> getProductById(@PathVariable Long id) {
         ProductResponseDTO product = productService.getProductById(id);
         return ResponseEntity.status(HttpStatus.OK).body(product);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/name/{name}")
     public ResponseEntity<ProductResponseDTO> getProductByName(@PathVariable String name) {
         ProductResponseDTO product = productService.getProductByName(name);
         return ResponseEntity.status(HttpStatus.OK).body(product);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/category/{categoryId}")
     public ResponseEntity<List<ProductResponseDTO>> getProductsByCategory(@PathVariable Long categoryId) {
         List<ProductResponseDTO> products = productService.getProductsByCategory(categoryId);
         return ResponseEntity.status(HttpStatus.OK).body(products);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/supplier/{supplierId}")
     public ResponseEntity<List<ProductResponseDTO>> getProductsBySupplierId(@PathVariable Long supplierId) {
         List<ProductResponseDTO> products = productService.getProductBySupplierId(supplierId);
         return ResponseEntity.status(HttpStatus.OK).body(products);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/search/{name}")
     public ResponseEntity<List<ProductResponseDTO>> searchProductsByName(@PathVariable String name) {
         List<ProductResponseDTO> products = productService.findByNameContainingIgnoreCase(name);
         return ResponseEntity.status(HttpStatus.OK).body(products);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/stock/less/{stockThreshold}")
     public ResponseEntity<List<ProductResponseDTO>> getProductsByStockLessThan(@PathVariable int stockThreshold) {
         List<ProductResponseDTO> products = productService.findByStockLessThan(stockThreshold);
         return ResponseEntity.status(HttpStatus.OK).body(products);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/stock/more/{stockThreshold}")
     public ResponseEntity<List<ProductResponseDTO>> getProductsByStockMoreThan(@PathVariable int stockThreshold) {
         List<ProductResponseDTO> products = productService.findByStockMoreThan(stockThreshold);
         return ResponseEntity.status(HttpStatus.OK).body(products);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<ProductResponseDTO> updateProduct(@PathVariable Long id, @Valid @RequestBody ProductRequestDTO productRequest) {
         ProductResponseDTO updatedProduct = productService.updateProduct(id, productRequest);
         return ResponseEntity.status(HttpStatus.OK).body(updatedProduct);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteProduct(@PathVariable Long id) {
         productService.deleteProduct(id);

--- a/src/main/java/com/sebastian/inventory_management/controller/SupplierController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/SupplierController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,42 +30,49 @@ public class SupplierController {
         this.supplierService = supplierService;
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<SupplierResponseDTO> createSupplier(@RequestBody SupplierRequestDTO supplierRequest) {
         SupplierResponseDTO createdSupplier = supplierService.saveSupplier(supplierRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdSupplier);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/{id}")
     public ResponseEntity<SupplierResponseDTO> getSupplierById(@PathVariable Long id){
         SupplierResponseDTO supplier = supplierService.getSupplierById(id);
         return ResponseEntity.status(HttpStatus.OK).body(supplier);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/name/{name}")
     public ResponseEntity<SupplierResponseDTO> getSupplierByName(@PathVariable String name){
         SupplierResponseDTO supplier = supplierService.getSupplierByName(name);
         return ResponseEntity.status(HttpStatus.OK).body(supplier);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping("/contact-email/{contactEmail}")
     public ResponseEntity<SupplierResponseDTO> getSupplierByContactEmail(@PathVariable String contactEmail){
         SupplierResponseDTO supplier = supplierService.getSupplierByContactEmail(contactEmail);
         return ResponseEntity.status(HttpStatus.OK).body(supplier);
     }
 
+    @PreAuthorize("hasAnyRole('ADMIN', 'EMPLOYEE')")
     @GetMapping
     public ResponseEntity<List<SupplierResponseDTO>> getAllSuppliers(){
         List<SupplierResponseDTO> suppliers = supplierService.getAllSuppliers();
         return ResponseEntity.status(HttpStatus.OK).body(suppliers);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteSupplier(@PathVariable Long id){
         supplierService.deleteSupplier(id);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<SupplierResponseDTO> updateSupplier(@PathVariable Long id, @RequestBody SupplierRequestDTO supplierRequest) {
         SupplierResponseDTO updatedSupplier = supplierService.updateSupplier(id, supplierRequest);

--- a/src/main/java/com/sebastian/inventory_management/controller/UserController.java
+++ b/src/main/java/com/sebastian/inventory_management/controller/UserController.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -31,42 +32,49 @@ public class UserController {
         this.userService = userService;
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PostMapping
     public ResponseEntity<UserResponseDTO> addUser(@Valid @RequestBody UserRequestDTO userRequestDTO) {
         UserResponseDTO createdUser = userService.addUser(userRequestDTO);
         return ResponseEntity.status(HttpStatus.CREATED).body(createdUser);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/{id}")
     public ResponseEntity<UserResponseDTO> getUserById(@PathVariable Long id){
         UserResponseDTO user = userService.getUserById(id);
         return ResponseEntity.status(HttpStatus.OK).body(user);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/username/{username}")
     public ResponseEntity<UserResponseDTO> getUserByUsername( @PathVariable String username){
         UserResponseDTO user = userService.getUserByUsername(username);
         return ResponseEntity.status(HttpStatus.OK).body(user);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping("/email/{email}")
     public ResponseEntity<UserResponseDTO> getUserByEmail( @PathVariable String email){
         UserResponseDTO user = userService.getUserByEmail(email);
         return ResponseEntity.status(HttpStatus.OK).body(user);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @GetMapping
     public ResponseEntity<List<UserResponseDTO>> getAllUsers(){
         List<UserResponseDTO> users = userService.getAllUsers();
         return ResponseEntity.status(HttpStatus.OK).body(users);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @PutMapping("/{id}")
     public ResponseEntity<UserResponseDTO> updateUser(@PathVariable Long id, @Valid @RequestBody UserRequestDTO userRequestDTO){
         UserResponseDTO updatedUser = userService.updateUser(id, userRequestDTO);
         return ResponseEntity.status(HttpStatus.OK).body(updatedUser);
     }
 
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteUser(@PathVariable Long id){
         userService.deleteUser(id);

--- a/src/main/java/com/sebastian/inventory_management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sebastian/inventory_management/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<Object> handleResourceNotFound(ResourceNotFoundException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.NOT_FOUND.value());
         body.put("error", "Not Found");
         body.put("message", ex.getMessage());
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.BAD_REQUEST.value());
         body.put("error", "Bad Request");
         body.put("message", ex.getMessage());
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InstantiationException.class)
     public ResponseEntity<Object> InstantiationException(InstantiationException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.BAD_REQUEST.value());
         body.put("error", "Bad Request");
         body.put("message", ex.getMessage());
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UsernameNotFoundException.class)
     public ResponseEntity<Object> UsernameNotFoundException(UsernameNotFoundException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.NOT_FOUND.value());
         body.put("error", "Not Found");
         body.put("message", ex.getMessage());
@@ -62,7 +62,7 @@ public class GlobalExceptionHandler {
      @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.FORBIDDEN.value());
         body.put("error", "Forbidden");
         body.put("message", "No tenés permiso para acceder a este recurso.");
@@ -72,7 +72,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
     public ResponseEntity<Object> handleAuthException(AuthenticationCredentialsNotFoundException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.UNAUTHORIZED.value());
         body.put("error", "Unauthorized");
         body.put("message", "Tenés que estar autenticado para acceder.");

--- a/src/main/java/com/sebastian/inventory_management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sebastian/inventory_management/exception/GlobalExceptionHandler.java
@@ -1,11 +1,14 @@
 package com.sebastian.inventory_management.exception;
 
+import java.nio.file.AccessDeniedException;
 import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -43,5 +46,36 @@ public class GlobalExceptionHandler {
         body.put("message", ex.getMessage());
 
         return new ResponseEntity<>(body, HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler(UsernameNotFoundException.class)
+    public ResponseEntity<Object> UsernameNotFoundException(UsernameNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.NOT_FOUND.value());
+        body.put("error", "Not Found");
+        body.put("message", ex.getMessage());
+
+        return new ResponseEntity<>(body, HttpStatus.NOT_FOUND);
+    }
+
+     @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.FORBIDDEN.value());
+        body.put("error", "Forbidden");
+        body.put("message", "No tenés permiso para acceder a este recurso.");
+        return new ResponseEntity<>(body, HttpStatus.FORBIDDEN);
+    }
+
+    @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
+    public ResponseEntity<Object> handleAuthException(AuthenticationCredentialsNotFoundException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", HttpStatus.UNAUTHORIZED.value());
+        body.put("error", "Unauthorized");
+        body.put("message", "Tenés que estar autenticado para acceder.");
+        return new ResponseEntity<>(body, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/sebastian/inventory_management/mapper/UserMapper.java
+++ b/src/main/java/com/sebastian/inventory_management/mapper/UserMapper.java
@@ -25,5 +25,6 @@ public interface UserMapper {
     @Mapping(target = "id", ignore = true)
     @Mapping(target = "movements", ignore = true)
     @Mapping(target = "enabled", ignore = true)
+    @Mapping(target = "authorities", ignore = true)
     void updateEntityFromDto(UserRequestDTO dto, @MappingTarget User entity);
 }

--- a/src/main/java/com/sebastian/inventory_management/model/Category.java
+++ b/src/main/java/com/sebastian/inventory_management/model/Category.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,7 +29,6 @@ public class Category {
     private Long id;
 
     @Column(name = "name", nullable = false, unique = true)
-    @NotBlank(message = "Name is mandatory")
     private String name;
 
     @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/sebastian/inventory_management/model/InventoryMovement.java
+++ b/src/main/java/com/sebastian/inventory_management/model/InventoryMovement.java
@@ -14,7 +14,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -33,11 +32,9 @@ public class InventoryMovement {
     private Long id;
 
     @Column(nullable = false)
-    @NotNull(message = "Quantity cannot be null")
     private int quantity;
 
     @Column(nullable = false, name = "timestamp")
-    @NotNull(message = "Timestamp cannot be null")
     private LocalDateTime timestamp;
 
     @ManyToOne
@@ -50,6 +47,5 @@ public class InventoryMovement {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "movement_type")
-    @NotNull(message = "Movement type cannot be null")
     private MovementType type;
 }

--- a/src/main/java/com/sebastian/inventory_management/model/InventoryMovement.java
+++ b/src/main/java/com/sebastian/inventory_management/model/InventoryMovement.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,6 +26,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class InventoryMovement {
 
     @Id

--- a/src/main/java/com/sebastian/inventory_management/model/Order.java
+++ b/src/main/java/com/sebastian/inventory_management/model/Order.java
@@ -15,8 +15,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,16 +33,13 @@ public class Order {
     private Long id;
 
     @Column(name = "order_number", nullable = false, unique = true)
-    @NotBlank(message = "Order number cannot be null")
     private String orderNumber;
 
     @Column(name = "order_date", nullable = false)
-    @NotNull(message = "Order date cannot be null")
     private LocalDateTime orderDate;
 
     @ManyToOne
     @JoinColumn(name = "supplier_id")
-    @NotNull(message = "Supplier cannot be null") 
     private Supplier supplier;
 
     @OneToMany(mappedBy = "order", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)

--- a/src/main/java/com/sebastian/inventory_management/model/OrderItem.java
+++ b/src/main/java/com/sebastian/inventory_management/model/OrderItem.java
@@ -10,8 +10,6 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,21 +28,16 @@ public class OrderItem {
     private Long id;
 
     @Column(nullable = false)
-    @NotNull(message = "Quantity cannot be null")
-    @Min(1)
     private int quantity;
 
     @Column(nullable = false)
-    @NotNull(message = "Price cannot be null")
     private BigDecimal price;
 
     @ManyToOne
     @JoinColumn(name = "order_id", nullable = false)
-    @NotNull(message = "Order cannot be null")
     private Order order;
 
     @ManyToOne
     @JoinColumn(name = "product_id", nullable = false)
-    @NotNull(message = "Product cannot be null")
     private Product product;
 }

--- a/src/main/java/com/sebastian/inventory_management/model/Product.java
+++ b/src/main/java/com/sebastian/inventory_management/model/Product.java
@@ -13,12 +13,6 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.DecimalMin;
-import jakarta.validation.constraints.Digits;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -37,34 +31,23 @@ public class Product {
     private Long id;
 
     @Column(name = "name", nullable = false, unique = true)
-    @NotBlank(message = "Name is mandatory")
-    @Size(max = 100, message = "Name must be less than 100 characters")
     private String name;
 
     @Column(name = "description", nullable = false)
-    @NotBlank(message = "Description is mandatory")
-    @Size(max = 255, message = "Description must be less than 255 characters")
     private String description;
 
     @Column(name = "stock", nullable = false)
-    @NotNull(message = "Stock cannot be null")
-    @Min(value = 0, message = "Stock cannot be negative")
-    private int stock;
+    private Integer stock;
 
     @Column(name = "price", nullable = false)
-    @NotNull(message = "Price cannot be null")
-    @DecimalMin(value = "0.0", inclusive = false, message = "Price must be greater than zero")
-    @Digits(integer = 10, fraction = 2, message = "Price format is invalid")
     private BigDecimal price;
 
     @ManyToOne
     @JoinColumn(name = "category_id", nullable = false)
-    @NotNull(message = "Category cannot be null")
     private Category category;
 
     @ManyToOne
     @JoinColumn(name = "supplier_id", nullable = false)
-    @NotNull(message = "Supplier cannot be null")
     private Supplier supplier;
 
     @OneToMany(mappedBy = "product", cascade = CascadeType.ALL)

--- a/src/main/java/com/sebastian/inventory_management/model/Supplier.java
+++ b/src/main/java/com/sebastian/inventory_management/model/Supplier.java
@@ -11,9 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -32,17 +29,12 @@ public class Supplier {
     private Long id;
 
     @Column(nullable = false, unique = true, name = "name")
-    @NotBlank(message = "Name is mandatory")
     private String name;
 
     @Column(nullable = false, unique = true, name = "contact_email")
-    @NotBlank(message = "Contact email is mandatory")
-    @Email(message = "Invalid email format") 
     private String contactEmail;
 
     @Column(nullable = false, unique = true, name = "phone_number")
-    @NotBlank(message = "Phone number is mandatory")
-    @Pattern(regexp = "\\d{10,15}", message = "Invalid phone number")
     private String phoneNumber;
 
     @OneToMany(mappedBy = "supplier", cascade = CascadeType.ALL, fetch = FetchType.LAZY)

--- a/src/main/java/com/sebastian/inventory_management/model/User.java
+++ b/src/main/java/com/sebastian/inventory_management/model/User.java
@@ -1,6 +1,11 @@
 package com.sebastian.inventory_management.model;
 
+import java.util.Collection;
 import java.util.List;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
 
 import com.sebastian.inventory_management.enums.Role;
 
@@ -14,8 +19,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -29,22 +32,19 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-public class User {
-    
+public class User implements UserDetails {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Column(nullable = false, name = "user_name")
-    @NotBlank(message = "Username is mandatory")
     private String username;
 
     @Column(nullable = false, unique = true)
-    @NotBlank(message = "Email is mandatory")
     private String email;
 
     @Column(nullable = false)
-    @NotBlank(message = "Password is mandatory")
     private String password;
 
     @Column(nullable = false)
@@ -53,9 +53,18 @@ public class User {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, name = "role")
-    @NotNull(message = "Role is mandatory")
     private Role role;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
     private List<InventoryMovement> movements;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(new SimpleGrantedAuthority("ROLE_" + role.name()));
+    }
+
+    @Override
+    public String getUsername() {
+        return this.email;
+    }
 }

--- a/src/main/java/com/sebastian/inventory_management/security/AuthService.java
+++ b/src/main/java/com/sebastian/inventory_management/security/AuthService.java
@@ -1,0 +1,67 @@
+package com.sebastian.inventory_management.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import com.sebastian.inventory_management.DTO.Auth.AuthenticationRequest;
+import com.sebastian.inventory_management.DTO.Auth.AuthenticationResponse;
+import com.sebastian.inventory_management.DTO.Auth.RegisterRequest;
+import com.sebastian.inventory_management.model.User;
+import com.sebastian.inventory_management.repository.UserRepository;
+import com.sebastian.inventory_management.service.IAuthService;
+
+@Service
+public class AuthService implements IAuthService {
+
+    private AuthenticationManager authenticationManager;
+    private JwtService jwtService;
+    private UserDetailsService userDetailsService;
+    private UserRepository userRepository;
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    public AuthService(AuthenticationManager authenticationManager, JwtService jwtService,
+            UserDetailsService userDetailsService, UserRepository userRepository, PasswordEncoder passwordEncoder) {
+        this.authenticationManager = authenticationManager;
+        this.jwtService = jwtService;
+        this.userDetailsService = userDetailsService;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+
+    }
+
+    @Override
+    public AuthenticationResponse login(AuthenticationRequest request) {
+        authenticationManager.authenticate(
+                new UsernamePasswordAuthenticationToken(request.getEmail(), request.getPassword()));
+
+        UserDetails user = userDetailsService.loadUserByUsername(request.getEmail());
+        String token = jwtService.generateToken(user);
+        return new AuthenticationResponse(token, user.getUsername(), user.getAuthorities().toString());
+    }
+
+    public AuthenticationResponse register(RegisterRequest request) {
+
+        if (userRepository.findByEmail(request.getEmail()).isPresent()) {
+            throw new IllegalArgumentException("Email already in use");
+        }
+
+        User user = new User();
+        user.setUsername(request.getUsername());
+        user.setEmail(request.getEmail());
+        user.setPassword(passwordEncoder.encode(request.getPassword()));
+        user.setRole(request.getRole());
+
+        userRepository.save(user);
+
+        String jwtToken = jwtService.generateToken(user);
+
+        return new AuthenticationResponse(jwtToken, user.getUsername(), user.getAuthorities().toString());
+    }
+
+}

--- a/src/main/java/com/sebastian/inventory_management/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sebastian/inventory_management/security/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.sebastian.inventory_management.security;
+
+import java.io.IOException;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.sebastian.inventory_management.model.User;
+import com.sebastian.inventory_management.repository.UserRepository;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtService jwtService;
+    private final UserRepository userRepository;
+
+    @SuppressWarnings("null")
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+
+        if (request.getServletPath().startsWith("/auth")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        final String authHeader = request.getHeader("Authorization");
+        final String jwt;
+        final String userEmail;
+
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        jwt = authHeader.substring(7);
+        userEmail = jwtService.extractUsername(jwt);
+
+        if (userEmail != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            User user = userRepository.findByEmail(userEmail).orElseThrow();
+
+            if (jwtService.isTokenValid(jwt, user)) {
+                UsernamePasswordAuthenticationToken authToken =
+                        new UsernamePasswordAuthenticationToken(user, null, user.getAuthorities());
+                        System.out.println("🚨 Roles cargados para " + user.getEmail() + ": " + user.getAuthorities());
+                authToken.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                SecurityContextHolder.getContext().setAuthentication(authToken);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/security/JwtService.java
+++ b/src/main/java/com/sebastian/inventory_management/security/JwtService.java
@@ -1,0 +1,58 @@
+package com.sebastian.inventory_management.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@Service
+public class JwtService {
+    
+    @Value("${jwt.secret}")
+    private String SECRET_KEY;
+
+    public String generateToken(UserDetails userDetails) {
+        return Jwts.builder()
+                .setSubject(userDetails.getUsername())
+                .setIssuedAt(new Date())
+                .setExpiration(Date.from(Instant.now().plus(1, ChronoUnit.DAYS)))
+                .signWith(getSigningKey(), SignatureAlgorithm.HS256)
+                .compact();
+    }
+
+    public String extractUsername(String token) {
+        return getClaims(token).getSubject();
+    }
+
+    public boolean isTokenValid(String token, UserDetails userDetails) {
+        String username = extractUsername(token);
+        return username.equals(userDetails.getUsername()) && !isTokenExpired(token);
+    }
+
+    private Claims getClaims(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(getSigningKey())
+                .build()
+                .parseClaimsJws(token)
+                .getBody();
+    }
+
+    private boolean isTokenExpired(String token) {
+        return getClaims(token).getExpiration().before(new Date());
+    }
+
+    private Key getSigningKey() {
+        byte[] keyBytes = SECRET_KEY.getBytes(StandardCharsets.UTF_8);
+        return Keys.hmacShaKeyFor(keyBytes);
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/security/SecurityConfig.java
+++ b/src/main/java/com/sebastian/inventory_management/security/SecurityConfig.java
@@ -1,0 +1,61 @@
+package com.sebastian.inventory_management.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+import com.sebastian.inventory_management.security.exceptions.CustomAccessDeniedHandler;
+import com.sebastian.inventory_management.security.exceptions.CustomAuthenticationEntryPoint;
+
+@Configuration
+@EnableWebSecurity
+@EnableMethodSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthFilter;
+    private final AuthenticationProvider authenticationProvider;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+
+    @Autowired
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthFilter, AuthenticationProvider authenticationProvider, 
+            CustomAuthenticationEntryPoint authenticationEntryPoint, CustomAccessDeniedHandler accessDeniedHandler) {
+        this.jwtAuthFilter = jwtAuthFilter;
+        this.authenticationProvider = authenticationProvider;
+        this.authenticationEntryPoint = authenticationEntryPoint;
+        this.accessDeniedHandler = accessDeniedHandler;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .exceptionHandling(exception -> exception
+                    .accessDeniedHandler(accessDeniedHandler)
+                    .authenticationEntryPoint(authenticationEntryPoint))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/auth/**").permitAll()
+                        .anyRequest().authenticated())
+                .sessionManagement(session -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authenticationProvider(authenticationProvider)
+                .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter.class);
+            
+
+        return http.build();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+        return config.getAuthenticationManager();
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/security/exceptions/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/sebastian/inventory_management/security/exceptions/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.sebastian.inventory_management.security.exceptions;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setContentType("application/json");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", 403);
+        body.put("error", "Forbidden");
+        body.put("message", "You do not have permission to access this resource.");
+
+        new ObjectMapper().writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/security/exceptions/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/sebastian/inventory_management/security/exceptions/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,34 @@
+package com.sebastian.inventory_management.security.exceptions;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json");
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", LocalDateTime.now());
+        body.put("status", 401);
+        body.put("error", "Unauthorized");
+        body.put("message", "You need to authenticate to access this resource.");
+
+        new ObjectMapper().writeValue(response.getOutputStream(), body);
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/service/IAuthService.java
+++ b/src/main/java/com/sebastian/inventory_management/service/IAuthService.java
@@ -1,0 +1,9 @@
+package com.sebastian.inventory_management.service;
+
+import com.sebastian.inventory_management.DTO.Auth.AuthenticationRequest;
+import com.sebastian.inventory_management.DTO.Auth.AuthenticationResponse;
+
+public interface IAuthService {
+
+    AuthenticationResponse login(AuthenticationRequest request);
+}

--- a/src/main/java/com/sebastian/inventory_management/service/IUserService.java
+++ b/src/main/java/com/sebastian/inventory_management/service/IUserService.java
@@ -15,4 +15,5 @@ public interface IUserService {
     UserResponseDTO getUserByEmail(String email);
     List<UserResponseDTO> getAllUsers();
     User getUserByIdEntity(Long id);
+    User getCurrentUser();
 }

--- a/src/main/java/com/sebastian/inventory_management/service/impl/InventoryMovementServiceImpl.java
+++ b/src/main/java/com/sebastian/inventory_management/service/impl/InventoryMovementServiceImpl.java
@@ -102,7 +102,7 @@ public class InventoryMovementServiceImpl implements IInventoryMovementService {
         return movementMapper.toDTOList(movements);
     }
 
-    private void updateStock(Product product, int quantity, MovementType type) {
+    public void updateStock(Product product, int quantity, MovementType type) {
         if (type == MovementType.IN) {
             product.setStock(product.getStock() + quantity);
         } else if (type == MovementType.OUT) {

--- a/src/main/java/com/sebastian/inventory_management/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sebastian/inventory_management/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -102,5 +103,12 @@ public class UserServiceImpl implements IUserService, UserDetailsService {
                 user.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
         );
+    }
+
+    @Override
+    public User getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.show-sql:true
 spring.jpa.hibernate.ddl-auto: update
 spring.jpa.properties.hibernate.dialect: org.hibernate.dialect.MySQLDialect
+jwt.secret=${JWT_SECRET}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.jpa.show-sql:true
 spring.jpa.hibernate.ddl-auto: update
 spring.jpa.properties.hibernate.dialect: org.hibernate.dialect.MySQLDialect
 jwt.secret=${JWT_SECRET}
+spring.jackson.serialization.write-dates-as-timestamps=false


### PR DESCRIPTION
## Fix Order-OrderItem Relationship and Inventory Movement Creation

This PR addresses a critical issue where OrderItem entities were failing to persist due to a null order_id, caused by the association not being properly established before saving. The createOrder method in OrderServiceImpl has been updated to ensure that each OrderItem is correctly linked to its parent Order before the initial save operation. We now assign the list of OrderItems to the Order before persisting it, allowing Hibernate to handle the cascading correctly. Additionally, inventory movements are created right after the order is saved, reflecting the stock updates for each item. This ensures that product quantities are adjusted accordingly and that the InventoryMovement records are generated with accurate timestamps and user information.