### PR TITLE
Feat: Fix Order-OrderItem Relationship and Inventory Movement Creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,10 @@
 			<version>0.11.5</version>
 			<scope>runtime</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.datatype</groupId>
+			<artifactId>jackson-datatype-jsr310</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/src/main/java/com/sebastian/inventory_management/DTO/InventoryMovement/InventoryMovementResponseDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/InventoryMovement/InventoryMovementResponseDTO.java
@@ -2,6 +2,7 @@ package com.sebastian.inventory_management.DTO.InventoryMovement;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sebastian.inventory_management.enums.MovementType;
 
 import lombok.AllArgsConstructor;
@@ -17,7 +18,10 @@ public class InventoryMovementResponseDTO {
     
     private Long id;
     private Integer quantity;
+
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime timestamp;
+    
     private Long productId;
     private String productName;
     private Long userId;

--- a/src/main/java/com/sebastian/inventory_management/DTO/Order/OrderResponseDTO.java
+++ b/src/main/java/com/sebastian/inventory_management/DTO/Order/OrderResponseDTO.java
@@ -3,6 +3,7 @@ package com.sebastian.inventory_management.DTO.Order;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sebastian.inventory_management.DTO.OrderItem.OrderItemResponseDTO;
 
 import lombok.AllArgsConstructor;
@@ -18,6 +19,8 @@ public class OrderResponseDTO {
     
     private Long id;
     private String orderNumber;
+    
+    @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
     private LocalDateTime orderDate;
 
     private Long supplierId;

--- a/src/main/java/com/sebastian/inventory_management/config/JacksonConfig.java
+++ b/src/main/java/com/sebastian/inventory_management/config/JacksonConfig.java
@@ -1,0 +1,21 @@
+package com.sebastian.inventory_management.config;
+
+import org.springframework.boot.autoconfigure.jackson.Jackson2ObjectMapperBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.registerModule(new JavaTimeModule());
+        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return mapper;
+    }
+}

--- a/src/main/java/com/sebastian/inventory_management/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/sebastian/inventory_management/exception/GlobalExceptionHandler.java
@@ -18,7 +18,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(ResourceNotFoundException.class)
     public ResponseEntity<Object> handleResourceNotFound(ResourceNotFoundException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.NOT_FOUND.value());
         body.put("error", "Not Found");
         body.put("message", ex.getMessage());
@@ -29,7 +29,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<Object> handleIllegalArgument(IllegalArgumentException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.BAD_REQUEST.value());
         body.put("error", "Bad Request");
         body.put("message", ex.getMessage());
@@ -40,7 +40,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(InstantiationException.class)
     public ResponseEntity<Object> InstantiationException(InstantiationException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.BAD_REQUEST.value());
         body.put("error", "Bad Request");
         body.put("message", ex.getMessage());
@@ -51,7 +51,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(UsernameNotFoundException.class)
     public ResponseEntity<Object> UsernameNotFoundException(UsernameNotFoundException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.NOT_FOUND.value());
         body.put("error", "Not Found");
         body.put("message", ex.getMessage());
@@ -62,7 +62,7 @@ public class GlobalExceptionHandler {
      @ExceptionHandler(AccessDeniedException.class)
     public ResponseEntity<Object> handleAccessDeniedException(AccessDeniedException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.FORBIDDEN.value());
         body.put("error", "Forbidden");
         body.put("message", "No tenés permiso para acceder a este recurso.");
@@ -72,7 +72,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(AuthenticationCredentialsNotFoundException.class)
     public ResponseEntity<Object> handleAuthException(AuthenticationCredentialsNotFoundException ex) {
         Map<String, Object> body = new HashMap<>();
-        body.put("timestamp", LocalDateTime.now());
+        body.put("timestamp", LocalDateTime.now().toString());
         body.put("status", HttpStatus.UNAUTHORIZED.value());
         body.put("error", "Unauthorized");
         body.put("message", "Tenés que estar autenticado para acceder.");

--- a/src/main/java/com/sebastian/inventory_management/model/InventoryMovement.java
+++ b/src/main/java/com/sebastian/inventory_management/model/InventoryMovement.java
@@ -15,6 +15,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -25,6 +26,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class InventoryMovement {
 
     @Id

--- a/src/main/java/com/sebastian/inventory_management/service/IUserService.java
+++ b/src/main/java/com/sebastian/inventory_management/service/IUserService.java
@@ -15,4 +15,5 @@ public interface IUserService {
     UserResponseDTO getUserByEmail(String email);
     List<UserResponseDTO> getAllUsers();
     User getUserByIdEntity(Long id);
+    User getCurrentUser();
 }

--- a/src/main/java/com/sebastian/inventory_management/service/impl/InventoryMovementServiceImpl.java
+++ b/src/main/java/com/sebastian/inventory_management/service/impl/InventoryMovementServiceImpl.java
@@ -102,7 +102,7 @@ public class InventoryMovementServiceImpl implements IInventoryMovementService {
         return movementMapper.toDTOList(movements);
     }
 
-    private void updateStock(Product product, int quantity, MovementType type) {
+    public void updateStock(Product product, int quantity, MovementType type) {
         if (type == MovementType.IN) {
             product.setStock(product.getStock() + quantity);
         } else if (type == MovementType.OUT) {

--- a/src/main/java/com/sebastian/inventory_management/service/impl/UserServiceImpl.java
+++ b/src/main/java/com/sebastian/inventory_management/service/impl/UserServiceImpl.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -102,5 +103,12 @@ public class UserServiceImpl implements IUserService, UserDetailsService {
                 user.getPassword(),
                 List.of(new SimpleGrantedAuthority("ROLE_" + user.getRole().name()))
         );
+    }
+
+    @Override
+    public User getCurrentUser() {
+        String email = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByEmail(email)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -7,3 +7,4 @@ spring.jpa.show-sql:true
 spring.jpa.hibernate.ddl-auto: update
 spring.jpa.properties.hibernate.dialect: org.hibernate.dialect.MySQLDialect
 jwt.secret=${JWT_SECRET}
+spring.jackson.serialization.write-dates-as-timestamps=false


### PR DESCRIPTION
## Fix Order-OrderItem Relationship and Inventory Movement Creation

This PR addresses a critical issue where OrderItem entities were failing to persist due to a null order_id, caused by the association not being properly established before saving. The createOrder method in OrderServiceImpl has been updated to ensure that each OrderItem is correctly linked to its parent Order before the initial save operation. We now assign the list of OrderItems to the Order before persisting it, allowing Hibernate to handle the cascading correctly. Additionally, inventory movements are created right after the order is saved, reflecting the stock updates for each item. This ensures that product quantities are adjusted accordingly and that the InventoryMovement records are generated with accurate timestamps and user information.
